### PR TITLE
Issue 1 check changelog before release

### DIFF
--- a/src/main/groovy/com/emetriq/gradle/plugin/changelog/ChangelogReleasePlugin.groovy
+++ b/src/main/groovy/com/emetriq/gradle/plugin/changelog/ChangelogReleasePlugin.groovy
@@ -119,8 +119,8 @@ class ChangelogReleasePlugin implements Plugin<Project> {
             } // no changes
         }
 
-        //project.tasks.build.dependsOn checkChangelog
         project.tasks.final.dependsOn finalizeChangelog
+        project.tasks.finalizeChangelog.dependsOn checkChangelog
         project.tasks.final.finalizedBy newChangelogEntry
     }
 

--- a/src/test/groovy/com/emetriq/gradle/plugin/changelog/ChangelogReleaseIntegrationTest.groovy
+++ b/src/test/groovy/com/emetriq/gradle/plugin/changelog/ChangelogReleaseIntegrationTest.groovy
@@ -72,9 +72,11 @@ class ChangelogReleaseIntegrationTest extends IntegrationSpec {
         git.commit(message: 'added a cool plugin')
 
         when:
-        runTasks('final') // final is the nebula-release task
+        def result = runTasks('final') // final is the nebula-release task
 
         then:
+        result.success
+
         File changelog = new File(projectDir, "changelog.md")
         changelog.text.contains('0.3.0')
         changelog.text.startsWith('## [NEXT RELEASE]\n... add new changes here!')

--- a/src/test/groovy/com/emetriq/gradle/plugin/changelog/ChangelogReleasePluginTest.groovy
+++ b/src/test/groovy/com/emetriq/gradle/plugin/changelog/ChangelogReleasePluginTest.groovy
@@ -50,7 +50,7 @@ class ChangelogReleasePluginTest extends ProjectSpec {
         project.plugins.apply(ChangelogReleasePlugin)
 
         then:
-        project.tasks.prepare.getDependsOn().contains(project.tasks.checkChangelog)
+        project.tasks.finalizeChangelog.getDependsOn().contains(project.tasks.checkChangelog)
         project.tasks.final.getDependsOn().contains(project.tasks.finalizeChangelog)
         project.tasks.final.getFinalizedBy().getDependencies(null).contains(project.tasks.newChangelogEntry)
     }

--- a/src/test/groovy/com/emetriq/gradle/plugin/changelog/ChangelogReleasePluginTest.groovy
+++ b/src/test/groovy/com/emetriq/gradle/plugin/changelog/ChangelogReleasePluginTest.groovy
@@ -40,6 +40,7 @@ class ChangelogReleasePluginTest extends ProjectSpec {
         then:
         project.tasks.find { it.name == 'newChangelogEntry' }
         project.tasks.find { it.name == 'finalizeChangelog' }
+        project.tasks.find { it.name == 'checkChangelog' }
     }
 
     def 'check task order'() {
@@ -49,6 +50,7 @@ class ChangelogReleasePluginTest extends ProjectSpec {
         project.plugins.apply(ChangelogReleasePlugin)
 
         then:
+        project.tasks.prepare.getDependsOn().contains(project.tasks.checkChangelog)
         project.tasks.final.getDependsOn().contains(project.tasks.finalizeChangelog)
         project.tasks.final.getFinalizedBy().getDependencies(null).contains(project.tasks.newChangelogEntry)
     }

--- a/src/test/groovy/com/emetriq/gradle/plugin/changelog/FailChangelogReleaseIntegrationTest.groovy
+++ b/src/test/groovy/com/emetriq/gradle/plugin/changelog/FailChangelogReleaseIntegrationTest.groovy
@@ -74,8 +74,6 @@ class FailChangelogReleaseIntegrationTest extends IntegrationSpec {
         when:
         ExecutionResult result = runTasks('checkChangelog')
 
-        println result.success
-
         then:
         !result.success
     }
@@ -105,7 +103,6 @@ class FailChangelogReleaseIntegrationTest extends IntegrationSpec {
 
         when:
         ExecutionResult result = runTasks('build')
-        println result.success
 
         then:
         result.success


### PR DESCRIPTION
I added a new task which adds an action to the build configuration phase and checks whether the changelog is filled.

The task can be run explicitly (checkChangelog). The action is also implicitly invoked if the task graph contains the final task.